### PR TITLE
Fix duplicate detect_platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 # Debug and test files
 debug_*.py
 test_*.py
+!tests_new/unit/test_platform_detection.py
 patch_*.py
 verify_*.py
 *.png

--- a/app/bot/utils.py
+++ b/app/bot/utils.py
@@ -52,29 +52,6 @@ from .messages import (
 logger = logging.getLogger(__name__)
 
 
-def detect_platform(url: str) -> str:
-    """Detect marketplace platform from URL.
-    
-    Args:
-        url: The URL to analyze.
-        
-    Returns:
-        Platform name ('ebay', 'grailed', 'profile', or 'unknown').
-    """
-    url_lower = url.lower()
-    
-    if "ebay." in url_lower:
-        return "ebay"
-    elif "grailed.com" in url_lower:
-        # Check if it's a profile URL or listing URL
-        if "/users/" in url_lower or url_lower.count("/") == 3:  # grailed.com/username
-            return "profile"
-        else:
-            return "grailed"
-    else:
-        return "unknown"
-
-
 def escape_markdown_v2(text: str) -> str:
     """Escape special characters for MarkdownV2 format.
 

--- a/tests_new/unit/test_platform_detection.py
+++ b/tests_new/unit/test_platform_detection.py
@@ -1,0 +1,15 @@
+from app.bot.utils import detect_platform
+
+
+class TestPlatformDetection:
+    def test_detect_platform_ebay(self, test_urls):
+        url = test_urls["ebay"][0]
+        assert detect_platform(url) == "ebay"
+
+    def test_detect_platform_grailed_listing(self, test_urls):
+        url = test_urls["grailed"][0]
+        assert detect_platform(url) == "grailed"
+
+    def test_detect_platform_grailed_profile(self, test_urls):
+        url = test_urls["grailed"][1]
+        assert detect_platform(url) == "profile"


### PR DESCRIPTION
## Summary
- consolidate the two detect_platform implementations
- allow adding new tests in gitignore
- test platform detection for eBay and Grailed URLs

## Testing
- `pytest -q tests_new/unit/test_platform_detection.py`
- `pytest -q tests_new/unit` *(fails: 18 failed, 15 passed)*


------
https://chatgpt.com/codex/tasks/task_e_6872c16f31b88329b8f8d39b49f5b9cf